### PR TITLE
use a version tag in Railway template

### DIFF
--- a/railway/Dockerfile
+++ b/railway/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/coder/coder:latest
+FROM ghcr.io/coder/coder:v0.22.0
 ENV PORT=3000
 ENV CODER_HTTP_ADDRESS=0.0.0.0:$PORT
 ARG RAILWAY_STATIC_URL=


### PR DESCRIPTION
We should use labeled versions instead of always using the latest ones. To avoid any possible regressions 