### PR TITLE
fix: force build packer images to allow overwrite and use workload identity provider for auth

### DIFF
--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -77,4 +77,4 @@ jobs:
           PRODUCT_IDENTIFIER: ${{ secrets.PRODUCT_IDENTIFIER }}
 
       - name: Submit image to GCP Marketplace
-        run: ./github/workflows/gcp/submit_image.sh
+        run: ./.github/workflows/gcp/submit_image.sh

--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          workload_identity_provider: projects/573722524737/locations/global/workloadIdentityPools/github/providers/github
-          service_account: coder-ci@coder-dogfood.iam.gserviceaccount.com
+          workload_identity_provider: projects/599002230295/locations/global/workloadIdentityPools/github-actions-pool/providers/github-actions-oidc-provider
+          service_account: coder-packages-ci@coder-enterprise-market-public.iam.gserviceaccount.com
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main

--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -58,6 +58,7 @@ jobs:
       - name: Build Artifact
         run: |
           packer build \
+            -force \
             -var "coder_version=${{ env.PKR_VAR_coder_version }}" \
             ./template.pkr.hcl
         env:

--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -39,7 +39,8 @@ jobs:
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: "${{ secrets.GOOGLE_CREDENTIALS }}"
+          workload_identity_provider: projects/573722524737/locations/global/workloadIdentityPools/github/providers/github
+          service_account: coder-ci@coder-dogfood.iam.gserviceaccount.com
 
       - name: Setup `packer`
         uses: hashicorp/setup-packer@main

--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -68,6 +68,7 @@ jobs:
 
       - name: Submit AMI to AWS Marketplace
         run: ./.github/workflows/aws/submit_ami.sh
+        continue-on-error: true
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/template.pkr.hcl
+++ b/template.pkr.hcl
@@ -19,10 +19,6 @@ local "safe_version" {
   expression = replace(var.coder_version, "v", "")
 }
 
-local "gcp_version" {
-  expression = replace(local.safe_version, ".", "-")
-}
-
 variable "append_version" {
   type    = string
   default = ""
@@ -57,12 +53,12 @@ source "amazon-ebs" "ubuntu" {
 
 source "googlecompute" "ubuntu" {
   project_id          = "coder-enterprise-market-public"
-  image_name          = "coder-v${local.gcp_version}${var.append_version}"
+  image_name          = "coder-v${replace(local.safe_version, ".", "-")}${replace(var.append_version, ".", "-")}"
   source_image_family = "ubuntu-2204-lts"
   image_licenses      = ["projects/coder-enterprise-market-public/global/licenses/cloud-marketplace-83f16b4fa9cb1dff-df1ebeb69c0ba664"]
 
   image_description = <<EOF
-  Coder v${local.gcp_version}${var.append_version}: Self-Hosted Remote Development Environments
+  Coder v${replace(local.safe_version, ".", "-")}${replace(var.append_version, ".", "-")}: Self-Hosted Remote Development Environments
 
   Ubuntu 22.04 AMI with Coder pre-installed, Docker, and TLS public tunnel.
 


### PR DESCRIPTION
This allows us to force rerun the workflow with same version (if needed)