### PR TITLE
Revert "fix: update AWS account owner ID"

### DIFF
--- a/template.pkr.hcl
+++ b/template.pkr.hcl
@@ -42,7 +42,7 @@ source "amazon-ebs" "ubuntu" {
       virtualization-type = "hvm"
     }
     most_recent = true
-    owners      = ["891377257240"]
+    owners      = ["099720109477"]
   }
   ssh_username = "ubuntu"
   tags = {


### PR DESCRIPTION
Reverts coder/packages#167
Owner ID is not what we thought. It should match the base image listing