### PR TITLE
fix: wipe PostgreSQL data to ensure unique deployment IDs

### DIFF
--- a/files/scripts/999-cleanup.sh
+++ b/files/scripts/999-cleanup.sh
@@ -30,6 +30,68 @@ rm -f /home/ubuntu/.ssh/authorized_keys
 chown root:root /
 chmod o-w /
 
+# Stop Coder service to ensure clean shutdown before wiping data
+systemctl stop coder
+
+# Clean PostgreSQL data directory to remove deployment ID
+# This ensures each marketplace installation gets a unique deployment ID
+# Fix for: https://github.com/coder/packages/issues/180
+# Problem: All marketplace images had the same deployment ID because Coder was started
+# during image build, which generated and saved a deployment ID in the PostgreSQL database
+PG_VERSION=15  # Version set in 013-postgresql.sh
+PG_DATA_DIR="/var/lib/postgresql/${PG_VERSION}/main"
+if [ -d "$PG_DATA_DIR" ]; then
+  echo "Stopping PostgreSQL service..."
+  systemctl stop postgresql
+  
+  echo "Wiping PostgreSQL data directory to remove Coder deployment ID..."
+  # Backup pg_hba.conf and postgresql.conf
+  cp "$PG_DATA_DIR/pg_hba.conf" "/tmp/pg_hba.conf.bak" 2>/dev/null
+  cp "$PG_DATA_DIR/postgresql.conf" "/tmp/postgresql.conf.bak" 2>/dev/null
+  
+  # Remove data directory
+  rm -rf "$PG_DATA_DIR"
+  
+  # Recreate data directory
+  mkdir -p "$PG_DATA_DIR"
+  chown -R postgres:postgres "$PG_DATA_DIR"
+  chmod 700 "$PG_DATA_DIR"
+  
+  # Initialize PostgreSQL database
+  echo "Initializing fresh PostgreSQL database..."
+  sudo -u postgres /usr/lib/postgresql/$PG_VERSION/bin/initdb -D "$PG_DATA_DIR"
+  
+  # Restore configuration if it existed
+  if [ -f "/tmp/pg_hba.conf.bak" ]; then
+    cp "/tmp/pg_hba.conf.bak" "$PG_DATA_DIR/pg_hba.conf"
+    chown postgres:postgres "$PG_DATA_DIR/pg_hba.conf"
+  fi
+  
+  if [ -f "/tmp/postgresql.conf.bak" ]; then
+    cp "/tmp/postgresql.conf.bak" "$PG_DATA_DIR/postgresql.conf"
+    chown postgres:postgres "$PG_DATA_DIR/postgresql.conf"
+  fi
+  
+  # Start PostgreSQL temporarily to recreate database structure
+  systemctl start postgresql
+  
+  # Wait for PostgreSQL to start
+  sleep 5
+  
+  # Recreate database and user (same as in 013-postgresql.sh)
+  echo "Recreating database structure..."
+  sudo -u postgres psql <<EOF
+CREATE ROLE coder LOGIN SUPERUSER PASSWORD 'coder';
+CREATE DATABASE coder OWNER coder;
+EOF
+  
+  # Stop PostgreSQL again
+  systemctl stop postgresql
+  
+  # Clean up temp files
+  rm -f "/tmp/pg_hba.conf.bak" "/tmp/postgresql.conf.bak"
+fi
+
 # Clean up Coder cache
 rm -rf /home/coder/.config
 


### PR DESCRIPTION
## Summary
- Stops the Coder service in the cleanup script
- Wipes the PostgreSQL data directory and reinitializes it
- Ensures each marketplace installation gets a unique deployment ID

## Test plan
- Build a GCP Marketplace image with these changes
- Verify the PostgreSQL data directory is properly cleaned up
- Check that deployments have unique IDs in telemetry

Fixes #180

🤖 Generated with [Claude Code](https://claude.ai/code)