### PR TITLE
fix: do not start coder service during the image build

### DIFF
--- a/files/scripts/014-coder.sh
+++ b/files/scripts/014-coder.sh
@@ -2,4 +2,4 @@
 
 curl -L https://coder.com/install.sh | sh
 
-systemctl enable --now coder
+systemctl enable coder


### PR DESCRIPTION
Solves #180 
This will make the Coder service start when the image is deployed and should create a unique deployment ID.