### PR TITLE
fix: update machine images on each release

### DIFF
--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set packer variables (repository_dispatch)
-        if: github.event_name == 'repository_dispatch' && github.event.client_payload.release_channel == 'stable'
+        if: github.event_name == 'repository_dispatch'
         run: |
           echo "PKR_VAR_coder_version=${{ github.event.client_payload.coder_version }}" >> "$GITHUB_ENV"
           echo "PKR_VAR_append_version=${{ github.event.client_payload.append_version }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
We were previously only building the images on `stable` releases which is a rare event and usually a `mainline` is promoted to `stable`