### PR TITLE
chore: group depdendabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       - "render"
     schedule:
       interval: "weekly"
+    groups:
+      coder-image:
+        patterns:
+          - "*"


### PR DESCRIPTION
Would reduce the number of version updates PRs by half. 