### PR TITLE
fix: only publish CE marketplace listing for stable releases

### DIFF
--- a/.github/workflows/aws/submit_ce.sh
+++ b/.github/workflows/aws/submit_ce.sh
@@ -47,6 +47,17 @@ echo "Product ID:     ${PRODUCT_ID}"
 echo "Image URI:      ${IMAGE_URI}"
 echo ""
 
+# --- Skip if already published ---
+if aws ecr describe-images \
+    --registry-id "${ECR_ACCOUNT}" \
+    --repository-name "${ECR_REPO}" \
+    --image-ids imageTag="${IMAGE_TAG}" \
+    --region "${ECR_REGION}" \
+    --output text > /dev/null 2>&1; then
+  echo "Image ${IMAGE_TAG} already exists in ECR. Skipping."
+  exit 0
+fi
+
 # --- Step 1: Pull and push image to ECR ---
 echo ">>> Pulling and pushing image to ECR..."
 # Pull the docker image from the GCR public registry 

--- a/.github/workflows/machine_images.yaml
+++ b/.github/workflows/machine_images.yaml
@@ -78,6 +78,9 @@ jobs:
           PRODUCT_IDENTIFIER: ${{ secrets.AWS_PRODUCT_IDENTIFIER }}
       
       - name: Submit image to AWS Marketplace CE
+        if: >-
+          github.event.client_payload.release_channel == 'stable'
+          || github.event_name == 'workflow_dispatch'
         run: ./.github/workflows/aws/submit_ce.sh
         continue-on-error: true
         env:


### PR DESCRIPTION
The CE marketplace submission from #255 runs on every release dispatch. It should only run for stable releases (the CE listing tracks stable, not mainline).

Two changes:

1. **Workflow gate** — the CE step now only runs when `release_channel == 'stable'` (from the `coder/coder` dispatch payload) or on manual `workflow_dispatch`.
2. **ECR dedup** — early `describe-images` check in `submit_ce.sh` exits cleanly if the image tag already exists in ECR, making the script idempotent.

<details><summary>Context</summary>

`coder/coder`'s `release.yaml` sends a `repository_dispatch` with `release_channel` (`mainline`, `stable`, `rc`) to this repo. The GitHub API's `/releases/latest` endpoint always points to stable (set via `MakeLatest: "true"` during promotion). The CE listing should only update on stable promotions — mainline releases would just create noise in the marketplace.

The ECR check is the single source of truth for "already processed" — no external state needed. If the workflow is re-run for the same version, it skips cleanly.

</details>

---

*Generated by [Coder Agents](https://coder.com/agents).*